### PR TITLE
Create the admin user properly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ python manage.py migrate --run-syncdb
 python manage.py shell <<EOF
 from django.contrib.auth.models import User
 User.objects.filter(email='$ADMIN_EMAIL').delete()
-User.objects.create_superuser('$ADMIN_EMAIL', '$ADMIN_USERNAME', '$ADMIN_PASSWORD')
+User.objects.create_superuser('$ADMIN_USERNAME', '$ADMIN_EMAIL', '$ADMIN_PASSWORD')
 EOF
 
 echo "Running server..."


### PR DESCRIPTION
Fix #12 
According to https://docs.djangoproject.com/en/1.11/ref/contrib/auth/ the correct parameter order to use the `create_superuser` method is 
```
 create_superuser(username, email, password, **extra_fields)¶
```
