### PR TITLE
Changing volume mount from 'media' to 'protected_media'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       # Your photos go here
       - $HOME/Pictures/:/data
-      - media:/code/media
+      - media:/code/protected_media
     environment:
       - SECRET_KEY=change_meme
       # This is backend host from within the service, you dont need to change this


### PR DESCRIPTION
A small fix to the docker-compose file addressing an issue that makes the container quite big. In this way the user can store the media files outside the container as it was intended.

As I was working on a small VM with 10GB I suddenly realised what was eating all the space although I thought that all my media is taken out of the container and on a NFS mount :)

In case someone wants to move their 'protected_media' to somewhere else here is what I did:

1. Mount NFS or copy to '/data' in order to take it out of the container.
2. Stop the container
3. Remove the container and the volume
4. docker-compose up with the new docker-compose.yml
5. Move the 'protected_media' contents so they are accessible from the container.
