### PR TITLE
SECURITY - UserViewSet permission changes

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework import permissions
 
+from constance import config as site_config
+
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
     """
@@ -48,3 +50,12 @@ class IsPhotoOrAlbumSharedTo(permissions.BasePermission):
                 return True
 
         return False
+
+
+class IsRegistrationAllowed(permissions.BasePermission):
+    """
+    Custom permission to only allow if registration is allowed globally.
+    """
+
+    def has_permission(self, request, view):
+        return bool(site_config.ALLOW_REGISTRATION)

--- a/api/views.py
+++ b/api/views.py
@@ -55,7 +55,7 @@ from api.serializers_serpy import AlbumDateListWithPhotoHashSerializer as AlbumD
 from api.serializers_serpy import PhotoSuperSimpleSerializer as PhotoSuperSimpleSerializerSerpy
 from api.serializers_serpy import PhotoSuperSimpleSerializerWithAddedOn as PhotoSuperSimpleSerializerWithAddedOnSerpy
 from api.serializers_serpy import SharedPhotoSuperSimpleSerializer as SharedPhotoSuperSimpleSerializerSerpy
-from api.permissions import IsOwnerOrReadOnly, IsUserOrReadOnly, IsPhotoOrAlbumSharedTo
+from api.permissions import IsOwnerOrReadOnly, IsUserOrReadOnly, IsPhotoOrAlbumSharedTo, IsRegistrationAllowed
 
 from api.face_classify import train_faces, cluster_faces
 from api.social_graph import build_social_graph, build_ego_graph
@@ -1219,7 +1219,11 @@ class UserViewSet(viewsets.ModelViewSet):
         return queryset
 
     def get_permissions(self):
-        if self.request.method == 'GET' or self.request.method == 'POST':
+        if self.action == 'create':
+            self.permission_classes = (IsRegistrationAllowed, )
+        elif self.action == 'list':
+            self.permission_classes = (IsAdminUser, )
+        elif self.request.method == 'GET' or self.request.method == 'POST':
             self.permission_classes = (AllowAny, )
         else:
             self.permission_classes = (IsUserOrReadOnly, )


### PR DESCRIPTION
This changes the permissions of UserViewSet (/api/user) in two ways:

* create checks the ALLOW_REGISTRATION site config - without this
change, the setting is a front-end only setting and even when disabled,
new accounts may be created

* list is limited to admin users - without this change, any user or an
unauthenticated user would be able to query the backend for all users,
including their email addresses