### PR TITLE
Bump to gunicorn 20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ Flask==1.0
 Flask-Cors==3.0.3
 Flask-RESTful==0.3.6
 geopy==1.11.0
-gunicorn==19.8.1
+gunicorn==20.0.2
 # idna==2.5
 ipdb==0.10.3
 ipython==6.1.0


### PR DESCRIPTION
This PR bumps gunicorn to the latest version, fixing the following error that is present given the current Dockerfile.

```
<snip>
    from gunicorn.workers.async import AsyncWorker
                              ^
SyntaxError: invalid syntax
]
```

gunicorn<19.9.0 has a module named `gunicorn.workers.async` that is not valid in Python 3.7 (benoitc/gunicorn#1795).